### PR TITLE
更新README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This version is packaged with Electron and JavaScript
 該版本與Electron以及其他JavaScript編碼打包
 
 # Supported Platforms 支援平台
-Windows (64-bit), macOS (64-bit), Linux (Run Source Code with Command Prompt)
+Windows (64-bit), macOS (64-bit), Linux (Run Source Code with console or terminal)
+
+視窗(64位元), macOS(64位元), Linux(使用控制檯或終端運行源代碼)
 
 # Creators 創作者
 Jmak, TLC, Vertrak, keanucode, Jono997, AXIS5, i0nTempest


### PR DESCRIPTION
將『command prompt』更改爲『console or terminal』,這是對Linux的錯誤描述,它在Linux下不被稱爲『Command Prompt』｡